### PR TITLE
Add Docker build workflow with conda-lock update

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,104 @@
+name: Update Lock Files and Build Docker Image
+
+on:
+  push:
+    # trigger when any one of these files have been changed
+    paths:
+      - 'environment.yml'
+      - 'Dockerfile'
+      - 'conda-lock.yml'
+      - '.github/workflows/docker-build.yml'
+  # also allow manual trigger
+  workflow_dispatch:
+
+jobs:
+  update-lock-file:
+    runs-on: ubuntu-latest
+    outputs:
+      lock-file-updated: ${{ steps.check-changes.outputs.changed }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # use a different environment name, base is a reserved environment name
+      - name: Set up Conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          # change this python version to match project python version
+          python-version: '3.11'
+          activate-environment: dockerlock
+          conda-remove-defaults: true
+
+      - name: Install conda-lock
+        shell: "bash -l {0}"
+        run: conda install -y -c conda-forge conda-lock
+
+      - name: Run conda-lock
+        shell: "bash -l {0}"
+        run: make cl
+
+      # checks if the conda-lock.yml file has any changes
+      - name: Check for changes
+        id: check-changes
+        run: |
+          if git diff --quiet conda-lock.yml; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      # if the conda-lock.yml file has changed, push the changes to the repo
+      - name: Commit and push lock file
+        if: steps.check-changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add conda-lock.yml
+          git commit -m ":wrench: Update conda-lock.yml"
+          git push origin main
+
+  build-and-push-docker:
+    needs: update-lock-file
+    if: always() && needs.update-lock-file.result != 'failure'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Pull latest changes
+        run: git pull origin ${{ github.ref_name }}
+
+      # set up docker so it can build multiple architectures
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # log into docker hub
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # build and push the container
+      # build intel + arm containers
+      # push the container to docker hub (under the dockerhub username)
+      # tag the container as latest, current github hash, and branch name
+      # use the hash version for fixed container version
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/docker-condalock-jupyterlab:latest
+            ${{ secrets.DOCKER_USERNAME }}/docker-condalock-jupyterlab:${{ github.sha }}
+            ${{ secrets.DOCKER_USERNAME }}/docker-condalock-jupyterlab:${{ github.ref_name }}
+          cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/docker-condalock-jupyterlab:buildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/docker-condalock-jupyterlab:buildcache,mode=max


### PR DESCRIPTION
This workflow updates the conda-lock file and builds a Docker image when specified files change or manually triggered. It includes steps for checking changes, committing updates, and building multi-architecture Docker images.